### PR TITLE
Fix projection window overlay menubar on Mac OS

### DIFF
--- a/src/macwindowhelper.h
+++ b/src/macwindowhelper.h
@@ -1,0 +1,10 @@
+// macwindowhelper.h
+#pragma once
+
+#include <QWidget>
+
+#if defined(Q_OS_MAC)
+void makeWindowCoverMenuBar(QWidget *widget);
+#else
+inline void makeWindowCoverMenuBar(QWidget *) {}
+#endif

--- a/src/macwindowhelper.mm
+++ b/src/macwindowhelper.mm
@@ -1,0 +1,19 @@
+// macwindowhelper.mm
+#import "macwindowhelper.h"
+
+#if defined(Q_OS_MAC)
+#import <AppKit/AppKit.h>
+
+void makeWindowCoverMenuBar(QWidget *widget) {
+    if (!widget) return;
+
+    NSView *nativeView = (__bridge NSView *)widget->winId();
+    if (!nativeView) return;
+
+    NSWindow *nsWindow = [nativeView window];
+    if (!nsWindow) return;
+
+    [nsWindow setLevel:NSMainMenuWindowLevel + 1];
+    [nsWindow setStyleMask:NSWindowStyleMaskBorderless];
+}
+#endif

--- a/src/projectionwindow.cpp
+++ b/src/projectionwindow.cpp
@@ -14,6 +14,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Subtivals.  If not, see <http://www.gnu.org/licenses/>
  **/
+
 #include <QtCore/QSettings>
 #include <QtCore/qmath.h>
 #include <QtGui/QCursor>
@@ -22,19 +23,23 @@
 
 #include "subtitlestyle.h"
 #include "projectionwindow.h"
+#include "macwindowhelper.h"
 
 ProjectionWindow::ProjectionWindow(QWidget *parent)
     : SubtitlesForm(parent), m_hideDesktop(false), m_monitor(-1),
       m_resizable(false) {
-  Qt::WindowFlags flags = Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint |
-                          Qt::X11BypassWindowManagerHint;
+  Qt::WindowFlags flags = Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint;
 #ifdef WIN32
   flags |= Qt::SubWindow;
+#endif
+#ifdef Q_OS_LINUX
+  flags |= Qt::X11BypassWindowManagerHint;
 #endif
   setStyleSheet("background:transparent;");
   setAttribute(Qt::WA_TranslucentBackground);
   setWindowFlags(flags);
   setCursor(QCursor(Qt::BlankCursor));
+  makeWindowCoverMenuBar(this);
 }
 
 ProjectionWindow::~ProjectionWindow() {}

--- a/src/subtivals.pro
+++ b/src/subtivals.pro
@@ -43,7 +43,14 @@ HEADERS  += mainwindow.h \
     styleadvanced.h \
     shortcuteditor.h \
     wizard.h \
-    weblive.h
+    weblive.h \
+    macwindowhelper.h
+
+OBJECTIVE_SOURCES += macwindowhelper.mm
+
+macx {
+    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.15
+}
 
 FORMS    += mainwindow.ui \
     subtitlesform.ui \


### PR DESCRIPTION
A hack to make sure the projection window can overlap menu bar on Mac OS.

Before:


<img width="580" alt="Screenshot 2025-06-17 at 10 58 37" src="https://github.com/user-attachments/assets/2593ca4d-8c12-45d2-85ad-f2a6ccbb59e9" />

After:

<img width="1089" alt="Screenshot 2025-06-17 at 10 57 37" src="https://github.com/user-attachments/assets/3fac92ef-c7e3-47a7-a050-3fae891d47c3" />
