### PR TITLE
Build on old GLibC

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     env:
       QT_VERSION: "6.9.1"
       APP_NAME: subtivals


### PR DESCRIPTION
This way the AppImage can run on Ubuntu 20.04 and above