### PR TITLE
Fix #356: prevent operator comments to be duplicated over several subtitles

### DIFF
--- a/examples/comments.srt
+++ b/examples/comments.srt
@@ -2,3 +2,13 @@
 00:00:00,000 --> 00:00:05,000
 This is projected text
 # This is information for the operator
+
+2
+00:00:05,000 --> 00:00:10,000
+This is a #hashtag and this is a # symbol
+# Hola!
+
+3
+00:00:10,000 --> 00:00:15,000
+Here we don't have operator comments.
+

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -417,6 +417,7 @@ void Script::loadFromSrt(QStringList content) {
         subtitle->setComments(comments);
         m_subtitles.append(subtitle);
         text.clear();
+        comments.clear();
 
         section = SECTION_NONE;
       } else if (line.startsWith("#")) {


### PR DESCRIPTION
Fix #356