### PR TITLE
Fix #358: Use `//` instead of `#` for comments

### DIFF
--- a/examples/comments.srt
+++ b/examples/comments.srt
@@ -1,12 +1,12 @@
 ﻿1
 00:00:00,000 --> 00:00:05,000
 This is projected text
-# This is information for the operator
+// This is information for the operator
 
 2
 00:00:05,000 --> 00:00:10,000
 This is a #hashtag and this is a # symbol
-# Hola!
+// Hola!
 
 3
 00:00:10,000 --> 00:00:15,000

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -420,8 +420,8 @@ void Script::loadFromSrt(QStringList content) {
         comments.clear();
 
         section = SECTION_NONE;
-      } else if (line.startsWith("#")) {
-        comments = line.replace("#", "");
+      } else if (line.startsWith("//")) {
+        comments = line.replace("//", "");
       } else {
         line = sp2nbsp(line);
         text.append(line);
@@ -473,8 +473,8 @@ void Script::loadFromTxt(QStringList content) {
         comments.clear();
 
         section = SECTION_NONE;
-      } else if (line.startsWith("#")) {
-        comments = line.replace("#", "");
+      } else if (line.startsWith("//")) {
+        comments = line.replace("//", "");
       } else {
         // In TXT format : <word> is equivalent to <i>word</i>
         line = line.replace(QRegularExpression("<([^i/][^>]+)>"), "<i>\\1</i>");


### PR DESCRIPTION
Fix #358